### PR TITLE
Updated to reflect changes on the live site

### DIFF
--- a/scenarioA/services/defence/jobs/index.html
+++ b/scenarioA/services/defence/jobs/index.html
@@ -137,7 +137,7 @@
             <div class="mwstext section"><div class="row profile">
  <div class="col-md-6">
   <h1 property="name" id="wb-cont">Jobs in national security and defence</h1>
-  <p class="pagetag">Apply for a job with the Government of Canada in the field of national security and defence.</p>
+  <p class="pagetag">Jobs with the Canadian Armed Forces, RCMP, Security Intelligence, Border services, Defence and Public Safety.</p>
   <section class="followus mrgn-bttm-md">
    <h2> Follow: </h2>
    <ul>
@@ -157,21 +157,21 @@
   <h2>Services and information</h2>
   <div class="row">
    <section class="col-md-6">
-    <h3><a href="../../../department-national-defence/services/caf-jobs.html"  class="ch5">Canadian Armed Forces (CAF) jobs</a></h3>
-    <p>Browse jobs with the CAF. Career options, pay and benefits. Talk to a recruiter near you.</p>
+    <h3><a href="../../../department-national-defence/services/caf-jobs.html"  class="ch5">Canadian Armed Forces jobs</a></h3>
+    <p>Find a job in the military. Career options, pay and benefits. Talk to a recruiter near you.</p>
    </section>
    <section class="col-md-6">
     <h3><a href="http://www.rcmp-grc.gc.ca/recruiting-recrutement/index-eng.htm"  class="ch5">Royal Canadian Mounted Police (RCMP) careers</a></h3>
-    <p>Check out career options and the salary and benefits of working for the RCMP.</p>
+    <p>Career options, salaries and benefits of working for the RCMP.</p>
    </section>
    <div class="clearfix"></div>
    <section class="col-md-6">
     <h3><a href="https://www.canada.ca/en/security-intelligence-service/corporate/csis-jobs.html"  class="ch5">Canadian Security Intelligence Service (CSIS) careers</a></h3>
-    <p>Apply for a position and learn about the various jobs, benefits and work environment at CSIS.</p>
+    <p>Apply for a position. Jobs, benefits and work environment at CSIS.</p>
    </section>
    <section class="col-md-6">
     <h3><a href="http://www.cbsa-asfc.gc.ca/job-emploi/bso-asf/menu-eng.html"  class="ch5">Canada Border Services Agency (CBSA) careers</a></h3>
-    <p>Find out how you can become a Border Services Officer and learn about the field of border security.</p>
+    <p>Become a border services officer. Salary and benefits.</p>
    </section>
    <section class="col-md-6">
     <h3><a href="/en/department-national-defence/corporate/job-opportunities/civilian-jobs.html"  class="ch5">Civilian jobs at National Defence</a></h3>
@@ -179,7 +179,7 @@
    </section>
    <section class="col-md-6">
     <h3><a href="https://www.cse-cst.gc.ca/en/careers-carrieres"  class="ch5">Communications Security Establishment (CSE) Canada careers</a></h3>
-    <p>Apply for a position, learn about careers, salaries, benefits and life at CSE Canada.</p>
+    <p>Apply for a position. Careers, salaries, benefits and life at CSE Canada.</p>
    </section>
    <div class="clearfix"></div>
    <section class="col-md-6">
@@ -197,14 +197,14 @@
    <h2 class="mrgn-tp-0">Most requested</h2>
    <ul class="lst-spcd">
     <li><a href="/en/department-national-defence/campaigns/in-demand-jobs.html">The Canadian Armed Forces is hiring</a></li>
-    <li><a href="/en/department-national-defence/services/caf-jobs/browse-jobs.html">Find a job in the CAF</a></li>
-    <li><a href="/en/department-national-defence/services/caf-jobs/talk-to-a-recruiter.html">Talk to a CAF recruiter</a></li>
-    <li><a href="/en/department-national-defence/services/caf-jobs/apply-now/apply-now.html">Apply to the CAF</a></li>
-    <li><a href="http://www.forces.gc.ca/en/caf-community-pay/pay-rates.page">Pay rates for CAF members</a></li>
+    <li><a href="/en/department-national-defence/services/caf-jobs/browse-jobs.html">Find a job in the military</a></li>
+    <li><a href="/en/department-national-defence/services/caf-jobs/talk-to-a-recruiter.html">Talk to a Canadian Armed Forces recruiter</a></li>
+    <li><a href="/en/department-national-defence/services/caf-jobs/apply-now/apply-now.html">Apply to the Canadian Armed Forces</a></li>
+    <li><a href="http://www.forces.gc.ca/en/caf-community-pay/pay-rates.page">Pay rates for Canadian Armed Forces members</a></li>
     <li><a href="https://www.cbsa-asfc.gc.ca/job-emploi/bso-asf/menu-eng.html">Apply to be a Border services officer</a></li>
     <li><a href="http://www.rcmp.gc.ca/recruiting-recrutement/rec/requirements-exigences-eng.htm">Careers in the RCMP</a></li>
-    <li><a href="/en/department-national-defence/services/caf-jobs/career-options.html">Career options in the CAF</a></li>
-    <li><a href="/en/department-national-defence/services/caf-jobs/paid-education.html">How the CAF will pay for your education</a></li>
+    <li><a href="/en/department-national-defence/services/caf-jobs/career-options.html">Career options in the military</a></li>
+    <li><a href="/en/department-national-defence/services/caf-jobs/paid-education.html">How the Canadian Armed Forces will pay for your education</a></li>
    </ul>
   </div>
  </aside>


### PR DESCRIPTION
1)	Removed all references to CAF- spelled it out or replaced with "military"
2)	Added the word “military” to the doormat for Canadian Armed Forces jobs
3)	Updated the Border services officer doormat, the CSIS doormat, the RCMP doormat, and the CSE doormat based on live site changes (mostly removing extra words)
4)     Updated the Jobs in National Security and Defence title description to be more descriptive